### PR TITLE
Revert "Bump isort from 4.2.5 to 5.10.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ funcsigs==1.0.2
 ipdb==0.10.2
 ipython==7.16.3
 ipython-genutils==0.2.0
-isort==5.10.1
+isort==4.2.5
 mccabe==0.6.1
 mock==2.0.0
 packaging==16.8


### PR DESCRIPTION
Looks like this causes more trouble, can't run tests.